### PR TITLE
🤖 Renames inputTypes to portTypes

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -7,7 +7,7 @@ export default () => {
   return (
     <div className="wrapper">
       <NodeEditor
-        inputTypes={{
+        portTypes={{
           number: {
             label: "Number",
             name: "number",

--- a/example/src/TestRoutes/TestEditor.js
+++ b/example/src/TestRoutes/TestEditor.js
@@ -22,7 +22,7 @@ export default () => {
   return (
     <div className="wrapper" style={{width: 800, height: 600}}>
       <NodeEditor
-        inputTypes={{
+        portTypes={{
           number: {
             label: "Number",
             name: "number",

--- a/example/src/components/LogicEditor.js
+++ b/example/src/components/LogicEditor.js
@@ -36,7 +36,7 @@ export default ({
           <NodeEditor
             context={context}
             nodeTypes={nodeTypes}
-            inputTypes={inputTypes}
+            portTypes={inputTypes}
             defaultNodes={defaultNodes}
             nodes={nodes}
             ref={nodeEditor}

--- a/src/components/IoPorts/IoPorts.js
+++ b/src/components/IoPorts/IoPorts.js
@@ -8,7 +8,7 @@ import {
 } from "../../context";
 import Control from "../Control/Control";
 import Connection from "../Connection/Connection";
-import { InputTypesContext } from "../../context";
+import { PortTypesContext } from "../../context";
 import usePrevious from "../../hooks/usePrevious";
 
 const IoPorts = ({
@@ -18,7 +18,7 @@ const IoPorts = ({
   connections,
   inputData
 }) => {
-  const inputTypes = React.useContext(InputTypesContext);
+  const inputTypes = React.useContext(PortTypesContext);
   const triggerRecalculation = React.useContext(ConnectionRecalculateContext);
 
   return (
@@ -153,7 +153,7 @@ const Port = ({
 }) => {
   const nodesDispatch = React.useContext(NodeDispatchContext);
   const stageState = React.useContext(StageContext)
-  const inputTypes = React.useContext(InputTypesContext);
+  const inputTypes = React.useContext(PortTypesContext);
   const [isDragging, setIsDragging] = React.useState(false);
   const [dragStartCoordinates, setDragStartCoordinates] = React.useState({
     x: 0,

--- a/src/context.js
+++ b/src/context.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const NodeTypesContext = React.createContext()
-export const InputTypesContext = React.createContext()
+export const PortTypesContext = React.createContext()
 export const NodeDispatchContext = React.createContext()
 export const ConnectionRecalculateContext = React.createContext()
 export const ContextContext = React.createContext()

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Node from "./components/Node/Node";
 import Connections from "./components/Connections/Connections";
 import {
   NodeTypesContext,
-  InputTypesContext,
+  PortTypesContext,
   NodeDispatchContext,
   ConnectionRecalculateContext,
   ContextContext,
@@ -22,8 +22,8 @@ import styles from "./styles.css";
 export let NodeEditor = (
   {
     nodes: initialNodes,
-    nodeTypes,
-    inputTypes,
+    nodeTypes = {},
+    portTypes = {},
     defaultNodes = [],
     context = {},
     debug
@@ -31,8 +31,8 @@ export let NodeEditor = (
   ref
 ) => {
   const [nodes, dispatchNodes] = React.useReducer(
-    connectNodesReducer(nodesReducer, { nodeTypes, inputTypes }),
-    getInitialNodes(initialNodes, defaultNodes, nodeTypes, inputTypes)
+    connectNodesReducer(nodesReducer, { nodeTypes, portTypes }),
+    getInitialNodes(initialNodes, defaultNodes, nodeTypes, portTypes)
   );
   const stage = React.useRef();
   const [
@@ -66,7 +66,7 @@ export let NodeEditor = (
   }));
 
   return (
-    <InputTypesContext.Provider value={inputTypes}>
+    <PortTypesContext.Provider value={portTypes}>
       <NodeTypesContext.Provider value={nodeTypes}>
         <NodeDispatchContext.Provider value={dispatchNodes}>
           <ConnectionRecalculateContext.Provider value={triggerRecalculation}>
@@ -113,7 +113,7 @@ export let NodeEditor = (
           </ConnectionRecalculateContext.Provider>
         </NodeDispatchContext.Provider>
       </NodeTypesContext.Provider>
-    </InputTypesContext.Provider>
+    </PortTypesContext.Provider>
   );
 };
 NodeEditor = React.forwardRef(NodeEditor);

--- a/src/nodesReducer.js
+++ b/src/nodesReducer.js
@@ -107,7 +107,7 @@ const removeNode = (startNodes, nodeId) => {
   return nodes
 }
 
-export const getInitialNodes = (initialNodes = {}, defaultNodes = [], nodeTypes, inputTypes) => {
+export const getInitialNodes = (initialNodes = {}, defaultNodes = [], nodeTypes, portTypes) => {
   if(Object.keys(initialNodes).length){
     return initialNodes
   }else{
@@ -117,15 +117,15 @@ export const getInitialNodes = (initialNodes = {}, defaultNodes = [], nodeTypes,
         x: dNode.x,
         y: dNode.y,
         nodeType: dNode.type
-      }, {nodeTypes, inputTypes})
+      }, {nodeTypes, portTypes})
       return nodes
     }, {})
   }
 }
 
-const getDefaultData = ({ nodeType, inputTypes }) =>
+const getDefaultData = ({ nodeType, portTypes }) =>
   nodeType.inputs.reduce((obj, input) => {
-    const inputType = inputTypes[input.type];
+    const inputType = portTypes[input.type];
     obj[input.name || inputType.name] = (
       input.controls ||
       inputType.controls ||
@@ -137,7 +137,7 @@ const getDefaultData = ({ nodeType, inputTypes }) =>
     return obj;
   }, {});
 
-const nodesReducer = (nodes, action = {}, { nodeTypes, inputTypes }) => {
+const nodesReducer = (nodes, action = {}, { nodeTypes, portTypes }) => {
   switch (action.type) {
 
     case "ADD_CONNECTION": {
@@ -174,7 +174,7 @@ const nodesReducer = (nodes, action = {}, { nodeTypes, inputTypes }) => {
           },
           inputData: getDefaultData({
             nodeType: nodeTypes[nodeType],
-            inputTypes
+            portTypes
           })
         }
       };

--- a/src/tests/test.js
+++ b/src/tests/test.js
@@ -18,7 +18,7 @@ describe("<NodeEditor/>", () => {
       <NodeEditor
         nodes={exampleNodes}
         nodeTypes={nodeTypes}
-        inputTypes={portTypes}
+        portTypes={portTypes}
       />
     );
   });
@@ -33,7 +33,7 @@ describe("<Node/>", () => {
         <NodeEditor
           nodes={exampleNodes}
           nodeTypes={nodeTypes}
-          inputTypes={portTypes}
+          portTypes={portTypes}
           debug
         />
       </div>


### PR DESCRIPTION
`portTypes` and `nodeTypes` are now defaulted for simple instantiation of empty editors.