### PR TITLE
🚀 `spaceToPan` prop for using space to pan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flume",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "A node editor for React",
   "author": "chrisjpatty",
   "license": "MIT",

--- a/src/components/Node/Node.css
+++ b/src/components/Node/Node.css
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: column;
   z-index: 1;
+  cursor: default;
 }
 .label{
   font-size: 13px;

--- a/src/components/Stage/Stage.css
+++ b/src/components/Stage/Stage.css
@@ -34,6 +34,7 @@
   font-family: Helvetica, sans-serif;
   text-align: left;
   line-height: 1;
+  outline: none !important;
 }
 .wrapper * {
   box-sizing: border-box;

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ export let NodeEditor = (
     context = {},
     onChange,
     initialScale,
+    spaceToPan = false,
     debug
   },
   ref
@@ -93,6 +94,7 @@ export let NodeEditor = (
                 <Stage
                   scale={stageState.scale}
                   translate={stageState.translate}
+                  spaceToPan={spaceToPan}
                   dispatchStageState={dispatchStageState}
                   stageRef={stage}
                   numNodes={Object.keys(nodes).length}


### PR DESCRIPTION
🚀 New prop `spaceToPan` to require the spacebar to be pressed in order to pan the canvas. Defaults to false.
🐛 Canvas now auto-focuses when entered or clicked.
🐛 Text inputs may now be blurred by clicking on the canvas.
🤖 0.1.36 -> 0.1.37