### PR TITLE
fix broken links on faq page

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -34,7 +34,7 @@ Yes! Logic graphs generated through the Flume node editor are stored as plain JS
 
 ## The docs mention type safety, do I have to use Typescript to use Flume?
 
-Hard no. Typescript is a "typed" version of Javascript that makes it harder to write code that can crash unexpectedly. In some sense you can think of Flume as Typescript for visual logic editing. It accomplishes the same task, making it difficult (if not impossible), for users to create logic that will cause type errors. That being said, you are more than welcome to use Flume with Typescript. If you are a Typescript developer and would like to help create type definitions for Flume, please reach out through the [Github repo!](github.com/chrisjpatty/flume)
+Hard no. Typescript is a "typed" version of Javascript that makes it harder to write code that can crash unexpectedly. In some sense you can think of Flume as Typescript for visual logic editing. It accomplishes the same task, making it difficult (if not impossible), for users to create logic that will cause type errors. That being said, you are more than welcome to use Flume with Typescript. If you are a Typescript developer and would like to help create type definitions for Flume, please reach out through the [Github repo!](https://github.com/chrisjpatty/flume)
 
 ## Why should I use this node editor over the others out there?
 
@@ -42,19 +42,19 @@ Whoa there buster, no one's twistin' your arm. In seriousness though, there are 
 
 ## Can I use async data in my nodes?
 
-Yes and no. Currently the root engine is designed to be a fully synchronous process. That means if you want to use any asyncronous data in your nodes you should detect the need for, and fetch, that data ahead of time and provide it to the context of the root engine. I recognize this might be a constraint in some applications, especially server environments, and work is already being done to explore creating a version of the root engine that supports asynchronous execution. With the upcoming concurrent mode for React, this type of engine may be especially useful. If this sounds like a fun challenge that you'd like to help with, feel free to [hit me up on Twitter](twitter.com/chrisjpatty) and we'll chat!
+Yes and no. Currently the root engine is designed to be a fully synchronous process. That means if you want to use any asyncronous data in your nodes you should detect the need for, and fetch, that data ahead of time and provide it to the context of the root engine. I recognize this might be a constraint in some applications, especially server environments, and work is already being done to explore creating a version of the root engine that supports asynchronous execution. With the upcoming concurrent mode for React, this type of engine may be especially useful. If this sounds like a fun challenge that you'd like to help with, feel free to [hit me up on Twitter](https://twitter.com/chrisjpatty) and we'll chat!
 
 ## Is the node editor accessible?
 
-Accessiblity is a critical component of any application, and the Flume maintainers are committed to achieving full WCAG compliance. Flume already excels in this area over many existing node editor libraries by using semantic HTML elements for rendering rather than inaccessible solutions like html canvas or svg. However, because this kind of rich user-interface has no native equivalent, there are tradeoffs for various accessibility approaches, and work is on-going to ensure that the node editor matures quickly to be fully accessible. If you would like to help with this effort please reach out on the [Github repo](github.com/chrisjpatty/flume) or open a PR.
+Accessiblity is a critical component of any application, and the Flume maintainers are committed to achieving full WCAG compliance. Flume already excels in this area over many existing node editor libraries by using semantic HTML elements for rendering rather than inaccessible solutions like html canvas or svg. However, because this kind of rich user-interface has no native equivalent, there are tradeoffs for various accessibility approaches, and work is on-going to ensure that the node editor matures quickly to be fully accessible. If you would like to help with this effort please reach out on the [Github repo](https://github.com/chrisjpatty/flume) or open a PR.
 
 ## Is Flume production-ready?
 
-Flume was originally created to support some of my work at my full-time job, where it's currently being integrated into production products. That being said, as with any open-source library, time and effort is needed to fully mature the library. At the time of writing, Flume can be considered to be stable, but may have undiscovered bugs. If you are using Flume and think something isn't working the way you expect, **please** file an issue on the [Github repo](github.com/chrisjpatty/flume) so it can be addressed ASAP. If you want to contribute by helping write unit tests that would also be **greatly** appreciated.
+Flume was originally created to support some of my work at my full-time job, where it's currently being integrated into production products. That being said, as with any open-source library, time and effort is needed to fully mature the library. At the time of writing, Flume can be considered to be stable, but may have undiscovered bugs. If you are using Flume and think something isn't working the way you expect, **please** file an issue on the [Github repo](https://github.com/chrisjpatty/flume) so it can be addressed ASAP. If you want to contribute by helping write unit tests that would also be **greatly** appreciated.
 
 ## I have some ideas to make Flume better, how can I contribute?
 
-Fantastic! Right now, development on Flume is primarily driven by me, [Chris Patty](twitter.com/chrisjpatty). I would love to work with anyone who is interested in contributing! Hit me up on [Twitter](twitter.com/chrisjpatty), or feel free to open issues or pull requests to the [flume repo on Github](github.com/chrisjpatty/flume). All contributions are welcome!
+Fantastic! Right now, development on Flume is primarily driven by me, [Chris Patty](https://twitter.com/chrisjpatty). I would love to work with anyone who is interested in contributing! Hit me up on [Twitter](https://twitter.com/chrisjpatty), or feel free to open issues or pull requests to the [flume repo on Github](https://github.com/chrisjpatty/flume). All contributions are welcome!
 
 ## Is the Flume logo just two Pac-men kissing?
 


### PR DESCRIPTION
I noticed the twitter/github links on your FAQ page are all relative which points them at `https://flume.dev/docs/github.com/chrisjpatty/flume` instead of `https://github.com/chrisjpatty/flume`.

Fantastic project btw; been super fun to use so far!