### PR TITLE
🚀🐛 Circular connection warnings in the Node Editor

### DIFF
--- a/docs/docs/NodeEditor.mdx
+++ b/docs/docs/NodeEditor.mdx
@@ -6,7 +6,7 @@ title: "NodeEditor"
 
 ## Zooming & Panning
 
-By default, the node editor can be zoom in and out using the scroll wheel, and panned by dragging anywhere on the background. In this release these are the only methods of zooming and panning, but an upcoming release will likely add an optional UI for using these features.
+By default, the node editor can be zoomed in and out using the scroll wheel, and panned by dragging anywhere on the background. In this release these are the only methods of zooming and panning, but an upcoming release will likely add an optional UI for using these features.
 
 ## Importing
 
@@ -85,3 +85,11 @@ Optional. If the current node editor contains comment blocks, they will not be r
 ### `disableComments` : boolean
 
 Optional. Prevents the user from adding additional comments. Defaults to `false`.
+
+### `circularBehavior` : string
+
+Optional. Can be one of 3 possible values:
+
+- `prevent`: Default. When a user attempts to connect nodes in a way that would create a circular graph, the connection is rejected and a warning is displayed.
+- `warn`: Creating circular connections is allowed, but a warning is displayed.
+- `allow`: Creating circular connections is allowed without a warning.

--- a/docs/docs/comments.mdx
+++ b/docs/docs/comments.mdx
@@ -13,7 +13,7 @@ When programming, it's helpful to use comments to document your code. The same g
 
 ## Saving comments
 
-Comments have no effect on the function of your logic graphs, so they aren't stored with the nodes. Like with nodes, there are two ways to get coments in and out of the node editor.
+Comments have no effect on the function of your logic graphs, so they aren't stored with the nodes. Like with nodes, there are two ways to get comemnts in and out of the node editor.
 
 ### `onCommentsChange`
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -621,7 +621,7 @@ export default () => {
             y: -200
           }
         ]}
-        debug
+        // debug
       />
       <div style={{ marginTop: 30 }}>
         <Website nodes={nodes} />

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -613,7 +613,6 @@ export default () => {
         comments={comments}
         onChange={setNodes}
         onCommentsChange={setComments}
-        circularBehavior="allow"
         // disableZoom
         defaultNodes={[
           {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -613,7 +613,7 @@ export default () => {
         comments={comments}
         onChange={setNodes}
         onCommentsChange={setComments}
-        disableZoom
+        // disableZoom
         defaultNodes={[
           {
             type: "websiteAttributes",

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -613,6 +613,7 @@ export default () => {
         comments={comments}
         onChange={setNodes}
         onCommentsChange={setComments}
+        circularBehavior="allow"
         // disableZoom
         defaultNodes={[
           {

--- a/src/components/Comment/Comment.css
+++ b/src/components/Comment/Comment.css
@@ -12,6 +12,7 @@
   display: flex;
   text-shadow: 0px 1px rgba(255,255,255,.1);
   border: 1px solid rgba(168, 176, 181, 0.7);
+  user-select: none;
   &[data-color="red"]{
     background: rgba(213, 84, 103, 0.65);
     border-color: rgba(227, 85, 119, 0.65);

--- a/src/components/IoPorts/IoPorts.js
+++ b/src/components/IoPorts/IoPorts.js
@@ -250,10 +250,11 @@ const Port = ({
         const {
           portName: connectToPortName,
           nodeId: connectToNodeId,
-          portType: connectToPortType
+          portType: connectToPortType,
+          portTransputType: connectToTransputType
         } = e.target.dataset;
         const isNotSameNode = outputNodeId !== connectToNodeId;
-        if (isNotSameNode) {
+        if (isNotSameNode && connectToTransputType !== "output") {
           const inputWillAcceptConnection = inputTypes[
             connectToPortType
           ].acceptTypes.includes(type);
@@ -271,10 +272,11 @@ const Port = ({
         const {
           portName: inputPortName,
           nodeId: inputNodeId,
-          portType: inputNodeType
+          portType: inputNodeType,
+          portTransputType: inputTransputType
         } = e.target.dataset;
         const isNotSameNode = inputNodeId !== nodeId;
-        if (isNotSameNode) {
+        if (isNotSameNode && inputTransputType !== "output") {
           const inputWillAcceptConnection = inputTypes[
             inputNodeType
           ].acceptTypes.includes(type);

--- a/src/components/Toaster/Toaster.css
+++ b/src/components/Toaster/Toaster.css
@@ -31,6 +31,7 @@
   font-size: 14px;
   display: flex;
   flex-direction: column;
+  will-change: transform;
   &[data-type="danger"]{
     background: rgb(255, 116, 137);
     border-color: rgb(254, 99, 136);

--- a/src/components/Toaster/Toaster.css
+++ b/src/components/Toaster/Toaster.css
@@ -13,7 +13,7 @@
 }
 .toast{
   position: absolute;
-  left: calc(50% - 160px);
+  left: calc(50% - 200px);
   top: 0px;
   pointer-events: all;
   width: 400px;

--- a/src/components/Toaster/Toaster.css
+++ b/src/components/Toaster/Toaster.css
@@ -29,6 +29,8 @@
   animation: fade-in 150ms;
   user-select: none;
   font-size: 14px;
+  display: flex;
+  flex-direction: column;
   &[data-type="danger"]{
     background: rgb(255, 116, 137);
     border-color: rgb(254, 99, 136);
@@ -53,6 +55,14 @@
     animation: fade-out 150ms;
     animation-fill-mode: forwards;
   }
+}
+.toast p{
+  margin: 0px;
+}
+.title{
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 5px;
 }
 .timer{
   position: absolute;

--- a/src/components/Toaster/Toaster.css
+++ b/src/components/Toaster/Toaster.css
@@ -1,0 +1,114 @@
+.toaster{
+  position: absolute;
+  left: 0px;
+  bottom: 0px;
+  width: 100%;
+  height: 1px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 15px;
+  box-shadow: 0px 5px 10px -2px rgba(0,0,0,.3);
+  pointer-events: none;
+}
+.toast{
+  position: absolute;
+  left: calc(50% - 160px);
+  top: 0px;
+  pointer-events: all;
+  width: 400px;
+  padding: 10px;
+  padding-top: 7px;
+  padding-right: 16px;
+  border-radius: 6px;
+  background: rgba(231, 231, 231, 1);
+  border: 1px solid;
+  margin-bottom: 5px;
+  transition: transform 300ms;
+  flex: 0 0 auto;
+  animation: fade-in 150ms;
+  user-select: none;
+  font-size: 14px;
+  &[data-type="danger"]{
+    background: rgb(255, 116, 137);
+    border-color: rgb(254, 99, 136);
+    color: rgb(66, 6, 20);
+  }
+  &[data-type="info"]{
+    background: rgb(76, 193, 250);
+    border-color: rgb(103, 182, 255);
+    color: rgb(5, 36, 64);
+  }
+  &[data-type="success"]{
+    background: rgb(81, 230, 150);
+    border-color: rgb(85, 227, 150);
+    color: rgb(7, 57, 30);
+  }
+  &[data-type="warning"]{
+    background: rgb(245, 208, 93);
+    border-color: rgb(247, 235, 125);
+    color: rgb(83, 75, 8);
+  }
+  &[data-exiting=true]{
+    animation: fade-out 150ms;
+    animation-fill-mode: forwards;
+  }
+}
+.timer{
+  position: absolute;
+  bottom: -1px;
+  left: -1px;
+  width: calc(100% + 2px);
+  height: 3px;
+  background: rgba(0,0,0,.4);
+  transform-origin: left center;
+  animation: timer 1000ms linear;
+  animation-fill-mode: forwards;
+  z-index: 9;
+}
+.exitButton{
+  position: absolute;
+  right: 0px;
+  top: 0px;
+  width: 20px;
+  height: 20px;
+  padding: 0px;
+  background: none;
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 14px;
+  color: inherit;
+  opacity: .6;
+}
+.exitButton:hover{
+  opacity: .9;
+}
+
+@keyframes fade-in {
+  from{
+    opacity: 0;
+  }
+  to{
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from{
+    opacity: 1;
+  }
+  to{
+    opacity: 0;
+  }
+}
+
+@keyframes timer {
+  from{
+    transform: scaleX(1);
+  }
+  to{
+    transform: scaleX(0);
+  }
+}

--- a/src/components/Toaster/Toaster.js
+++ b/src/components/Toaster/Toaster.js
@@ -53,6 +53,7 @@ export default ({ toasts = [], dispatchToasts }) => {
 
 const Toast = ({
   id,
+  title,
   message,
   duration,
   type,
@@ -103,7 +104,10 @@ const Toast = ({
       onMouseEnter={stopTimer}
       onMouseLeave={resumeTimer}
     >
-      {message}
+      {
+        title ? <span className={styles.title}>{title}</span> : null
+      }
+      <p>{message}</p>
       {!paused && (
         <div
           className={styles.timer}

--- a/src/components/Toaster/Toaster.js
+++ b/src/components/Toaster/Toaster.js
@@ -1,0 +1,120 @@
+import React from "react";
+import styles from "./Toaster.css";
+
+export default ({ toasts = [], dispatchToasts }) => {
+  const setHeight = React.useCallback(
+    (id, height) => {
+      dispatchToasts({
+        type: "SET_HEIGHT",
+        id,
+        height
+      });
+    },
+    [dispatchToasts]
+  );
+
+  const startExit = React.useCallback(
+    id => {
+      dispatchToasts({
+        type: "SET_EXITING",
+        id
+      });
+    },
+    [dispatchToasts]
+  );
+
+  const removeToast = React.useCallback(
+    id => {
+      dispatchToasts({
+        type: "REMOVE_TOAST",
+        id
+      });
+    },
+    [dispatchToasts]
+  );
+
+  return (
+    <div className={styles.toaster}>
+      {toasts.map((toast, i) => {
+        return (
+          <Toast
+            {...toast}
+            onHeightReceived={setHeight}
+            onExitRequested={startExit}
+            onRemoveRequested={removeToast}
+            y={toasts.slice(0, i + 1).reduce((y, t) => t.height + y + 5, 0)}
+            key={toast.id}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+const Toast = ({
+  id,
+  message,
+  duration,
+  type,
+  exiting,
+  y,
+  onHeightReceived,
+  onExitRequested,
+  onRemoveRequested
+}) => {
+  const [paused, setPaused] = React.useState(false);
+  const wrapper = React.useRef();
+  const timer = React.useRef();
+
+  const stopTimer = React.useCallback(() => {
+    setPaused(true);
+    clearTimeout(timer.current);
+  }, []);
+
+  const resumeTimer = React.useCallback(() => {
+    setPaused(false);
+    timer.current = setTimeout(() => onExitRequested(id), duration);
+  }, [id, duration, onExitRequested]);
+
+  React.useLayoutEffect(() => {
+    const { height } = wrapper.current.getBoundingClientRect();
+    onHeightReceived(id, height);
+  }, [onHeightReceived, id]);
+
+  React.useEffect(() => {
+    resumeTimer();
+    return stopTimer;
+  }, [resumeTimer, stopTimer]);
+
+  const handleAnimationEnd = () => {
+    if (exiting) {
+      onRemoveRequested(id);
+    }
+  };
+
+  return (
+    <div
+      ref={wrapper}
+      className={styles.toast}
+      data-type={type}
+      style={{ transform: `translateY(-${y}px)` }}
+      data-exiting={exiting}
+      onAnimationEnd={handleAnimationEnd}
+      onMouseEnter={stopTimer}
+      onMouseLeave={resumeTimer}
+    >
+      {message}
+      {!paused && (
+        <div
+          className={styles.timer}
+          style={{ animationDuration: `${duration}ms` }}
+          onAnimationEnd={e => e.stopPropagation()}
+        />
+      )}
+      <button className={styles.exitButton} onClick={() => {
+        stopTimer()
+        onExitRequested(id)
+      }}>✕</button>
+    </div>
+  );
+};

--- a/src/components/Toaster/Toaster.js
+++ b/src/components/Toaster/Toaster.js
@@ -103,6 +103,7 @@ const Toast = ({
       onAnimationEnd={handleAnimationEnd}
       onMouseEnter={stopTimer}
       onMouseLeave={resumeTimer}
+      role="alert"
     >
       {
         title ? <span className={styles.title}>{title}</span> : null

--- a/src/index.js
+++ b/src/index.js
@@ -53,12 +53,13 @@ export let NodeEditor = (
   const editorId = useId();
   const cache = React.useRef(new Cache());
   const stage = React.useRef();
+  const [sideEffectToasts, setSideEffectToasts] = React.useState()
   const [toasts, dispatchToasts] = React.useReducer(toastsReducer, []);
   const [nodes, dispatchNodes] = React.useReducer(
     connectNodesReducer(
       nodesReducer,
       { nodeTypes, portTypes, cache },
-      toastsReducer
+      setSideEffectToasts
     ),
     {},
     () => getInitialNodes(initialNodes, defaultNodes, nodeTypes, portTypes)
@@ -121,6 +122,13 @@ export let NodeEditor = (
       onCommentsChange(comments);
     }
   }, [comments, previousComments, onCommentsChange]);
+
+  React.useEffect(() => {
+    if(sideEffectToasts){
+      dispatchToasts(sideEffectToasts)
+      setSideEffectToasts(null)
+    }
+  }, [sideEffectToasts])
 
   return (
     <PortTypesContext.Provider value={portTypes}>

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ export let NodeEditor = (
     disableComments = false,
     disableZoom = false,
     disablePan = false,
+    circularBehavior,
     debug
   },
   ref
@@ -58,7 +59,7 @@ export let NodeEditor = (
   const [nodes, dispatchNodes] = React.useReducer(
     connectNodesReducer(
       nodesReducer,
-      { nodeTypes, portTypes, cache },
+      { nodeTypes, portTypes, cache, circularBehavior },
       setSideEffectToasts
     ),
     {},

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ export let NodeEditor = (
 
   const recalculateConnections = React.useCallback(() => {
     createConnections(nodes, stageState, editorId);
-  }, [nodes, editorId]);
+  }, [nodes, editorId, stageState]);
 
   const recalculateStageRect = () => {
     stage.current = document

--- a/src/nodesReducer.js
+++ b/src/nodesReducer.js
@@ -1,4 +1,8 @@
-import { deleteConnection, deleteConnectionsByNodeId } from "./connectionCalculator";
+import {
+  deleteConnection,
+  deleteConnectionsByNodeId
+} from "./connectionCalculator";
+import { checkForCircularNodes } from "./utilities";
 const nanoid = require("nanoid");
 
 const addConnection = (nodes, input, output, portTypes) => {
@@ -27,7 +31,8 @@ const addConnection = (nodes, input, output, portTypes) => {
         outputs: {
           ...nodes[output.nodeId].connections.outputs,
           [output.portName]: [
-            ...(nodes[output.nodeId].connections.outputs[output.portName] || []),
+            ...(nodes[output.nodeId].connections.outputs[output.portName] ||
+              []),
             {
               nodeId: input.nodeId,
               portName: input.portName
@@ -36,8 +41,8 @@ const addConnection = (nodes, input, output, portTypes) => {
         }
       }
     }
-  }
-  return newNodes
+  };
+  return newNodes;
 };
 
 const removeConnection = (nodes, input, output) => {
@@ -57,11 +62,9 @@ const removeConnection = (nodes, input, output) => {
   const outputNode = nodes[output.nodeId];
   const filteredOutputNodes = outputNode.connections.outputs[
     output.portName
-  ].filter(
-    cnx => {
-      return cnx.nodeId === input.nodeId ? cnx.portName !== input.portName : true
-    }
-  );
+  ].filter(cnx => {
+    return cnx.nodeId === input.nodeId ? cnx.portName !== input.portName : true;
+  });
   const newOutputNode = {
     ...outputNode,
     connections: {
@@ -80,20 +83,19 @@ const removeConnection = (nodes, input, output) => {
   };
 };
 
-const getFilteredTransputs = (transputs, nodeId) => (
+const getFilteredTransputs = (transputs, nodeId) =>
   Object.entries(transputs).reduce((obj, [portName, transput]) => {
-    const newTransputs = transput.filter(t => t.nodeId !== nodeId)
-    if(newTransputs.length){
-      obj[portName] = newTransputs
+    const newTransputs = transput.filter(t => t.nodeId !== nodeId);
+    if (newTransputs.length) {
+      obj[portName] = newTransputs;
     }
-    return obj
-  }, {})
-)
+    return obj;
+  }, {});
 
 const removeConnections = (connections, nodeId) => ({
   inputs: getFilteredTransputs(connections.inputs, nodeId),
   outputs: getFilteredTransputs(connections.outputs, nodeId)
-})
+});
 
 const removeNode = (startNodes, nodeId) => {
   let { [nodeId]: deletedNode, ...nodes } = startNodes;
@@ -101,88 +103,105 @@ const removeNode = (startNodes, nodeId) => {
     obj[node.id] = {
       ...node,
       connections: removeConnections(node.connections, nodeId)
-    }
+    };
 
-    return obj
-  }, {})
-  deleteConnectionsByNodeId(nodeId)
-  return nodes
-}
+    return obj;
+  }, {});
+  deleteConnectionsByNodeId(nodeId);
+  return nodes;
+};
 
 const reconcileNodes = (initialNodes, nodeTypes, portTypes) => {
-  let nodes = {...initialNodes}
+  let nodes = { ...initialNodes };
 
   // Delete extraneous nodes
   let nodesToDelete = Object.values(nodes)
-    .map(node => !nodeTypes[node.type] ? node.id : undefined)
-    .filter(x => x)
+    .map(node => (!nodeTypes[node.type] ? node.id : undefined))
+    .filter(x => x);
 
   nodesToDelete.forEach(nodeId => {
-    nodes = nodesReducer(nodes, {
-      type: "REMOVE_NODE",
-      nodeId
-    }, {nodeTypes, portTypes})
-  })
+    nodes = nodesReducer(
+      nodes,
+      {
+        type: "REMOVE_NODE",
+        nodeId
+      },
+      { nodeTypes, portTypes }
+    );
+  });
 
   // Reconcile input data for each node
   let reconciledNodes = Object.values(nodes).reduce((nodesObj, node) => {
-    const nodeType = nodeTypes[node.type]
-    const defaultInputData = getDefaultData({nodeType, portTypes})
-    const currentInputData = Object.entries(node.inputData).reduce((dataObj, [key, data]) => {
-      if(defaultInputData[key] !== undefined){
-        dataObj[key] = data;
-      }
-      return dataObj;
-    }, {})
+    const nodeType = nodeTypes[node.type];
+    const defaultInputData = getDefaultData({ nodeType, portTypes });
+    const currentInputData = Object.entries(node.inputData).reduce(
+      (dataObj, [key, data]) => {
+        if (defaultInputData[key] !== undefined) {
+          dataObj[key] = data;
+        }
+        return dataObj;
+      },
+      {}
+    );
     const newInputData = {
       ...defaultInputData,
       ...currentInputData
-    }
+    };
     nodesObj[node.id] = {
       ...node,
       inputData: newInputData
-    }
-    return nodesObj
-  }, {})
+    };
+    return nodesObj;
+  }, {});
 
   // Reconcile node attributes for each node
   reconciledNodes = Object.values(reconciledNodes).reduce((nodesObj, node) => {
-    let newNode = { ...node }
-    const nodeType = nodeTypes[node.type]
-    if(nodeType.root !== node.root){
-      if(nodeType.root && !node.root){
-        newNode.root = nodeType.root
-      }
-      else if(!nodeType.root && node.root){
+    let newNode = { ...node };
+    const nodeType = nodeTypes[node.type];
+    if (nodeType.root !== node.root) {
+      if (nodeType.root && !node.root) {
+        newNode.root = nodeType.root;
+      } else if (!nodeType.root && node.root) {
         delete newNode.root;
       }
     }
-    nodesObj[node.id] = newNode
+    nodesObj[node.id] = newNode;
     return nodesObj;
-  }, {})
+  }, {});
 
-  return reconciledNodes
-}
+  return reconciledNodes;
+};
 
-export const getInitialNodes = (initialNodes = {}, defaultNodes = [], nodeTypes, portTypes) => {
-  const reconciledNodes = reconcileNodes(initialNodes, nodeTypes, portTypes)
+export const getInitialNodes = (
+  initialNodes = {},
+  defaultNodes = [],
+  nodeTypes,
+  portTypes
+) => {
+  const reconciledNodes = reconcileNodes(initialNodes, nodeTypes, portTypes);
 
   return {
     ...reconciledNodes,
     ...defaultNodes.reduce((nodes, dNode) => {
-      const nodeNotAdded = !Object.values(initialNodes).find(n => n.type === dNode.type)
-      if(nodeNotAdded){
-        nodes = nodesReducer(nodes, {
-          type: "ADD_NODE",
-          x: dNode.x || 0,
-          y: dNode.y || 0,
-          nodeType: dNode.type
-        }, {nodeTypes, portTypes})
+      const nodeNotAdded = !Object.values(initialNodes).find(
+        n => n.type === dNode.type
+      );
+      if (nodeNotAdded) {
+        nodes = nodesReducer(
+          nodes,
+          {
+            type: "ADD_NODE",
+            x: dNode.x || 0,
+            y: dNode.y || 0,
+            nodeType: dNode.type
+          },
+          { nodeTypes, portTypes }
+        );
       }
-      return nodes
+      return nodes;
     }, {})
-  }
-}
+  };
+};
 
 const getDefaultData = ({ nodeType, portTypes }) =>
   nodeType.inputs.reduce((obj, input) => {
@@ -198,22 +217,41 @@ const getDefaultData = ({ nodeType, portTypes }) =>
     return obj;
   }, {});
 
-const nodesReducer = (nodes, action = {}, { nodeTypes, portTypes, cache }) => {
+const nodesReducer = (
+  nodes,
+  action = {},
+  { nodeTypes, portTypes, cache },
+  dispatchToasts
+) => {
   switch (action.type) {
-
     case "ADD_CONNECTION": {
       const { input, output } = action;
       const inputIsNotConnected = !nodes[input.nodeId].connections.inputs[
         input.portName
       ];
-      if (inputIsNotConnected) return addConnection(nodes, input, output, portTypes);
-      else return nodes;
-  }
+      if (inputIsNotConnected) {
+        const newNodes = addConnection(nodes, input, output, portTypes);
+        const isCircular = checkForCircularNodes(newNodes, output.nodeId);
+        if (isCircular) {
+          dispatchToasts({
+            type: "ADD_TOAST",
+            title: "Unable to connect",
+            message: "Connecting these nodes would result in an infinite loop.",
+            toastType: "warning",
+            duration: 5000
+          });
+          return nodes;
+        } else {
+          return newNodes;
+        }
+      } else return nodes;
+    }
 
     case "REMOVE_CONNECTION": {
       const { input, output } = action;
-      const id = output.nodeId + output.portName + input.nodeId + input.portName;
-      delete cache.current.connections[id]
+      const id =
+        output.nodeId + output.portName + input.nodeId + input.portName;
+      delete cache.current.connections[id];
       deleteConnection({ id });
       return removeConnection(nodes, input, output);
     }
@@ -235,8 +273,8 @@ const nodesReducer = (nodes, action = {}, { nodeTypes, portTypes, cache }) => {
           nodeType: nodeTypes[nodeType],
           portTypes
         })
-      }
-      if(nodeTypes[nodeType].root){
+      };
+      if (nodeTypes[nodeType].root) {
         newNode.root = true;
       }
       return {
@@ -247,7 +285,7 @@ const nodesReducer = (nodes, action = {}, { nodeTypes, portTypes, cache }) => {
 
     case "REMOVE_NODE": {
       const { nodeId } = action;
-      return removeNode(nodes, nodeId)
+      return removeNode(nodes, nodeId);
     }
 
     case "SET_PORT_DATA": {
@@ -258,9 +296,9 @@ const nodesReducer = (nodes, action = {}, { nodeTypes, portTypes, cache }) => {
           ...nodes[nodeId].inputData[portName],
           [controlName]: data
         }
-      }
-      if(setValue){
-        newData = setValue(newData, nodes[nodeId].inputData)
+      };
+      if (setValue) {
+        newData = setValue(newData, nodes[nodeId].inputData);
       }
       return {
         ...nodes,
@@ -288,7 +326,9 @@ const nodesReducer = (nodes, action = {}, { nodeTypes, portTypes, cache }) => {
   }
 };
 
-export const connectNodesReducer = (reducer, environment) => (state, action) =>
-  reducer(state, action, environment);
+export const connectNodesReducer = (reducer, environment, dispatchToasts) => (
+  state,
+  action
+) => reducer(state, action, environment, dispatchToasts);
 
 export default nodesReducer;

--- a/src/toastsReducer.js
+++ b/src/toastsReducer.js
@@ -1,4 +1,3 @@
-import { Colors } from "./typeBuilders";
 const nanoid = require("nanoid");
 
 export default (toasts = [], action) => {
@@ -7,6 +6,7 @@ export default (toasts = [], action) => {
       return [
         {
           id: nanoid(5),
+          title: action.title,
           message: action.message,
           type: action.toastType || 'info',
           duration: action.duration || 10000,

--- a/src/toastsReducer.js
+++ b/src/toastsReducer.js
@@ -1,0 +1,50 @@
+import { Colors } from "./typeBuilders";
+const nanoid = require("nanoid");
+
+export default (toasts = [], action) => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return [
+        {
+          id: nanoid(5),
+          message: action.message,
+          type: action.toastType || 'info',
+          duration: action.duration || 10000,
+          height: 0,
+          exiting: false
+        },
+        ...toasts
+      ];
+    case "SET_HEIGHT": {
+      const index = toasts.findIndex(t => t.id === action.id);
+      return [
+        ...toasts.slice(0, index),
+        {
+          ...toasts[index],
+          height: action.height
+        },
+        ...toasts.slice(index + 1)
+      ];
+    }
+    case "SET_EXITING": {
+      const index = toasts.findIndex(t => t.id === action.id);
+      return [
+        ...toasts.slice(0, index),
+        {
+          ...toasts[index],
+          exiting: true
+        },
+        ...toasts.slice(index + 1)
+      ];
+    }
+    case "REMOVE_TOAST": {
+      const index = toasts.findIndex(t => t.id === action.id);
+      return [
+        ...toasts.slice(0, index),
+        ...toasts.slice(index + 1)
+      ];
+    }
+    default:
+      return toasts;
+  }
+};

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,23 @@
+export const checkForCircularNodes = (nodes, startNodeId) => {
+  let isCircular = false;
+  const walk = nodeId => {
+    const outputs = Object.values(nodes[nodeId].connections.outputs);
+    for (var i = 0; i < outputs.length; i++) {
+      if(isCircular){
+        break;
+      }
+      const outputConnections = outputs[i];
+      for (var k = 0; k < outputConnections.length; k++) {
+        const connectedTo = outputConnections[k]
+        if(connectedTo.nodeId === startNodeId){
+          isCircular = true;
+          break;
+        }else{
+          walk(connectedTo.nodeId)
+        }
+      }
+    }
+  }
+  walk(startNodeId)
+  return isCircular;
+}


### PR DESCRIPTION
🚀 Circular connections are now detected when attempting to connect nodes. By default these connections will be rejected, and a warning message will be displayed. This behavior may be overriden by a new NodeEditor prop.
🚀 New toast notification system. Toast notifications come in 4 types: info, warning, danger, and success.
🚀 New NodeEditor prop: `circularBehavior` with 3 possible values:
- `allow`: Circular connections are allowed with no warning.
- `warn`: Circular connections are allowed but with a warning.
- `prevent` Circular connections are not allowed, and a warning is shown if attempted. This is the default.

🐛 Corrects an issue where in some cases connections could be made by dropping on an output port.
🐛 All stage state changes now trigger connection recalculations.

Resolves #21 