### PR TITLE
Generate reproducible node ids when doing server side rendering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,9 @@ export let NodeEditor = (
     commentsReducer,
     initialComments || {}
   );
+  React.useEffect(() => {
+    dispatchNodes({ type: "HYDRATE_DEFAULT_NODES" });
+  }, []);
   const [
     shouldRecalculateConnections,
     setShouldRecalculateConnections
@@ -226,6 +229,6 @@ export let NodeEditor = (
 };
 NodeEditor = React.forwardRef(NodeEditor);
 export { FlumeConfig, Controls, Colors } from "./typeBuilders";
-export RootEngine from "./RootEngine";
+export { default as RootEngine} from "./RootEngine";
 export const useRootEngine = (nodes, engine, context) =>
   Object.keys(nodes).length ? engine.resolveRootNode(nodes, { context }) : {};

--- a/src/index.js
+++ b/src/index.js
@@ -229,6 +229,6 @@ export let NodeEditor = (
 };
 NodeEditor = React.forwardRef(NodeEditor);
 export { FlumeConfig, Controls, Colors } from "./typeBuilders";
-export { default as RootEngine} from "./RootEngine";
+export RootEngine from "./RootEngine";
 export const useRootEngine = (nodes, engine, context) =>
   Object.keys(nodes).length ? engine.resolveRootNode(nodes, { context }) : {};

--- a/src/tests/ssr.test.js
+++ b/src/tests/ssr.test.js
@@ -1,0 +1,39 @@
+import React from "react";
+import ReactDOM from "react-dom/server";
+import { render } from "@testing-library/react";
+import {  nodeTypes, portTypes } from "./nodes";
+import { NodeEditor } from "../";
+
+const CONSOLE_ERROR_OUTPUT = [];
+const ConsoleError = console.error;
+const mockedConsoleError = log => CONSOLE_ERROR_OUTPUT.unshift(log);
+
+describe("<NodeEditor/> Server Rendered", () => {
+  beforeEach(() => console.error = mockedConsoleError);
+
+  test("creates isomorphic ids", async () => {
+    const component = (
+      <NodeEditor
+        nodeTypes={nodeTypes}
+        portTypes={portTypes}
+        defaultNodes={[{ type: "number", x: 0, y: 0 }]}
+      />
+    );
+    const markup = ReactDOM.renderToString(component);
+    document.body.innerHTML = `<div>${markup}</div>`;
+    render(component, {
+      container: document.body.firstChild,
+      hydrate: true
+    });
+    // FIXME:: useLayoutEffect isn't supported with server-side rendering and is
+    // throwing errors. Once we fix it we can stop filtering out those errors in
+    // this test.
+    // https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
+    const warnings = CONSOLE_ERROR_OUTPUT.filter(
+      err => !err.includes('useLayoutEffect')
+    );
+    expect(warnings.length).toBe(0);
+  });
+
+  afterEach(() => console.error = ConsoleError);
+});


### PR DESCRIPTION
fixes https://github.com/chrisjpatty/flume/issues/23

This PR causes defaultNodes to be created with an id of `default-0`, `default-1`, `default-2`, etc on the first render. This ensures that a server-render and an initial client render match up. On the client we do a second pass and replace all of those default ids with a unique nanoid. That way we won't have id collisions between multiple instances of flume on the same page.