### PR TITLE
convert commonjs require with esm import

### DIFF
--- a/example/src/pages/Form/PreviewField.js
+++ b/example/src/pages/Form/PreviewField.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { PreviewFieldsDispatchContext } from "./Form";
 import resolveLogic from './resolveLogic'
-const nanoid = require("nanoid");
+import nanoid from "nanoid/non-secure/index";
 
 export default ({ field, fields }) => {
   const { label, value, disabled, visible, required } = resolveLogic(field, fields) || {};

--- a/example/src/pages/Form/fieldsReducer.js
+++ b/example/src/pages/Form/fieldsReducer.js
@@ -1,4 +1,4 @@
-const nanoid = require("nanoid");
+import nanoid from "nanoid/non-secure/index";
 
 const getAttributes = attributes =>
   attributes.reduce((obj, attr) => {

--- a/src/commentsReducer.js
+++ b/src/commentsReducer.js
@@ -1,4 +1,4 @@
-const nanoid = require("nanoid");
+import nanoid from "nanoid/non-secure/index";
 
 const setComment = (comments, id, merge) => ({
   ...comments,

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -1,6 +1,6 @@
 import React from "react";
 import styles from "./Checkbox.css";
-const nanoid = require("nanoid");
+import nanoid from "nanoid/non-secure/index";
 
 const Checkbox = ({ label, data, onChange }) => {
   const id = React.useRef(nanoid(10));

--- a/src/components/ContextMenu/ContextMenu.js
+++ b/src/components/ContextMenu/ContextMenu.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./ContextMenu.css";
 import clamp from "lodash/clamp";
-const nanoid = require("nanoid");
+import nanoid from "nanoid/non-secure/index";
 
 const ContextMenu = ({
   x,

--- a/src/nodesReducer.js
+++ b/src/nodesReducer.js
@@ -3,7 +3,7 @@ import {
   deleteConnectionsByNodeId
 } from "./connectionCalculator";
 import { checkForCircularNodes } from "./utilities";
-const nanoid = require("nanoid");
+import nanoid from "nanoid/non-secure/index";
 
 const addConnection = (nodes, input, output, portTypes) => {
   const newNodes = {

--- a/src/toastsReducer.js
+++ b/src/toastsReducer.js
@@ -1,4 +1,4 @@
-const nanoid = require("nanoid");
+import nanoid from "nanoid/non-secure/index";
 
 export default (toasts = [], action) => {
   switch (action.type) {


### PR DESCRIPTION
Replaced 
```javascript 
const nanoid = require("nanoid")
```
with
```javascript 
import nanoid from "nanoid/non-secure/index"
```
 to drop nodejs dependency to target issue #52.