### PR TITLE
Add Options object to be accessible by the useRootEngine function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,5 +232,5 @@ export let NodeEditor = (
 NodeEditor = React.forwardRef(NodeEditor);
 export { FlumeConfig, Controls, Colors } from "./typeBuilders";
 export { RootEngine } from "./RootEngine";
-export const useRootEngine = (nodes, engine, context) =>
-  Object.keys(nodes).length ? engine.resolveRootNode(nodes, { context }) : {};
+export const useRootEngine = (nodes, engine, context, options = {}) =>
+  Object.keys(nodes).length ? engine.resolveRootNode(nodes, {...options, context }) : {};


### PR DESCRIPTION
Being able to pass the options for a React hook could be useful if the developer want to change the default Options, currently the 
`engine.resolveRootNode` accepts options.
This is only a quality of life change, because anyone can create a custom `useRootEngine`.