### PR TITLE
setNodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,10 @@ export let NodeEditor = (
     },
     getComments: () => {
       return comments;
+    },
+    setNodes: newNodes => {
+      dispatchNodes({ type: "SET_NODES", nodes: newNodes });
+      triggerRecalculation();
     }
   }));
 

--- a/src/nodesReducer.js
+++ b/src/nodesReducer.js
@@ -329,6 +329,12 @@ const nodesReducer = (
       return removeNode(nodes, nodeId);
     }
 
+    case "SET_NODES": {
+      const newNodes = { ...action.nodes };
+      nodesReducer(newNodes, { type: "HYDRATE_DEFAULT_NODES", nodes: newNodes }, { nodeTypes, portTypes, cache, circularBehavior, context, connectionMode }, dispatchToasts);
+      return newNodes;
+    }
+
     case "HYDRATE_DEFAULT_NODES": {
       const newNodes = { ...nodes };
       for (const key in newNodes) {


### PR DESCRIPTION
**What was changed:**
  - Added an imperative method (setNodes) to the NodeEditor
  - Added a new dispatch action to nodesReducer to implement the new action "SET_NODES"
  
**Usage:**

pseudo-code below:
```jsx

const nodeEditor = React.useRef()

const loadNewNodes= () => {
  const newNodes = newNodes.from.somewhere()
  
  nodeEditor.current.setNodes(newNodes);
}

return (
<>
  <button onClick={loadNewNodes}>Click me</button>
  <NodeEditor
    ref={nodeEditor}
    ...
    />
    </>
  )
```