### PR TITLE
Mark a default (root) node with [data-flume-component-is-root]

### DIFF
--- a/src/components/Node/Node.js
+++ b/src/components/Node/Node.js
@@ -21,6 +21,7 @@ const Node = ({
   connections,
   type,
   inputData,
+  root,
   onDragStart,
   renderNodeHeader
 }) => {
@@ -170,6 +171,7 @@ const Node = ({
       innerRef={nodeWrapper}
       data-node-id={id}
       data-flume-component="node"
+      data-flume-component-is-root={!!root}
       onContextMenu={handleContextMenu}
       stageState={stageState}
       stageRect={stageRect}


### PR DESCRIPTION
**What was done:**
  Marked node tags with `data-flume-component-is-root` attribute. It receives `true` if the node is a root (default) node, and `false` otherwise.
  
  **Why it was done:** To be able to customise default nodes via CSS, like
  
  ```css
  [data-flume-component-is-root="true"] {
    border: 1px solid red;
  }
  ```