### PR TITLE
select: getOptions async and isOptionEqualToValue

### DIFF
--- a/src/components/Control/Control.js
+++ b/src/components/Control/Control.js
@@ -22,6 +22,7 @@ const Control = ({
   triggerRecalculation,
   updateNodeConnections,
   getOptions,
+  isOptionEqualToValue,
   setValue,
   defaultValue,
   isMonoControl
@@ -56,8 +57,9 @@ const Control = ({
           <Select
             {...commonProps}
             options={
-              getOptions ? getOptions(inputData, executionContext) : options
+              getOptions ? getOptions(inputData, executionContext, nodeId) : options
             }
+            isOptionEqualToValue={isOptionEqualToValue}
             placeholder={placeholder}
           />
         );
@@ -75,8 +77,9 @@ const Control = ({
             allowMultiple
             {...commonProps}
             options={
-              getOptions ? getOptions(inputData, executionContext) : options
+              getOptions ? getOptions(inputData, executionContext, nodeId) : options
             }
+            isOptionEqualToValue={isOptionEqualToValue}
             placeholder={placeholder}
             label={label}
           />

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -6,8 +6,11 @@ import styles from "./Select.css";
 
 const MAX_LABEL_LENGTH = 50;
 
+const isOptionEqualToValueDefault = (option, value) => option === value
+
 const Select = ({
   options = [],
+  isOptionEqualToValue,
   placeholder = "[Select an option]",
   onChange,
   data,
@@ -19,6 +22,15 @@ const Select = ({
     y: 0
   });
   const wrapper = React.useRef();
+  const [ theOptions, setTheOptions ] = React.useState([])
+
+  React.useEffect(() => {
+    if (options.then) {
+      options.then(setTheOptions)
+    } else {
+      setTheOptions(options)
+    }
+  }, [ options ])
 
   const closeDrawer = () => {
     setDrawerOpen(false);
@@ -47,14 +59,17 @@ const Select = ({
     onChange([...data.slice(0, optionIndex), ...data.slice(optionIndex + 1)]);
   };
 
-  const getFilteredOptions = () => (
+  const getFilteredOptions = React.useCallback(() => (
     allowMultiple ?
-    options.filter(opt => !data.includes(opt.value))
-    : options
-  )
+    theOptions.filter(opt => !data.includes(opt.value))
+    : theOptions
+  ), [ theOptions, data ])
 
   const selectedOption = React.useMemo(() => {
-    const option = options.find(o => o.value === data);
+    const option = theOptions.find(o => isOptionEqualToValue
+                                    ? isOptionEqualToValue(o.value, data)
+                                    : isOptionEqualToValueDefault(o.value, data)
+                                  );
     if (option) {
       return {
         ...option,
@@ -64,7 +79,7 @@ const Select = ({
             : option.label
       };
     }
-  }, [options, data]);
+  }, [theOptions, data]);
 
   return (
     <React.Fragment>
@@ -73,7 +88,10 @@ const Select = ({
           <div className={styles.chipsWrapper}>
             {data.map((val, i) => {
               const optLabel =
-                (options.find(opt => opt.value === val) || {}).label || "";
+                (theOptions.find(opt => isOptionEqualToValue
+                                  ? isOptionEqualToValue(opt.value, val)
+                                  : isOptionEqualToValueDefault(opt.value, val)
+                                ) || {}).label || "";
               return (
                 <OptionChip
                   onRequestDelete={() => handleOptionDeleted(i)}


### PR DESCRIPTION
**What was done**
- The `options` property, in Select control, now accepts Promises
- Control and Select has a new property, `isOptionEqualToValue`

**Why it was done**
- Async methods allows us to pass options to Select from, for example, a `fetch` call. (callbacks can do it too, but I feel async are cooler)

Example: 
```js
controls: [
      Controls.select({
        name: "myCustomers",
        label: "Customers",
        placeholder: '(Select one customer)',
        getOptions: async (inputData, executionContext) => {
          const res = await fetch('/api/customer')
          const json = await res.json()
          
          return (json.result.map(item => ({
            value: item.id,
            label: item.name
          })))
        }
      })
    ]
```

That alone would enable us more options to obtain.. er.. options.

But, would be more interesting to pass not the `id` as value, the object itself would be better since we wouldn't need to fetch it again later.

So, the property `isOptionEqualToValue` will give us the answer to 'how an option object is equal to a potential string (or numeric) value?'

Same example, objects as values instead of ids:

```js
controls: [
      Controls.select({
        name: "myCustomers",
        label: "Customers",
        placeholder: '(Select one customer)',
        getOptions: async (inputData, executionContext) => {
          const res = await fetch('/api/customer')
          const json = await res.json()
          
          return (json.result.map(item => ({
            value: item,
            label: item.name
          })))
        },
        isOptionEqualToValue: (option, value) => option.id === value.id
      })
    ]
```
That way, at the node inputs resolve phase, we have the selected object to handle.
