### PR TITLE
add portType to connection

### DIFF
--- a/src/components/IoPorts/IoPorts.tsx
+++ b/src/components/IoPorts/IoPorts.tsx
@@ -375,7 +375,8 @@ const Port = ({
             nodesDispatch?.({
               type: NodesActionType.ADD_CONNECTION,
               input: { nodeId: connectToNodeId, portName: connectToPortName },
-              output: { nodeId: outputNodeId, portName: outputPortName }
+              output: { nodeId: outputNodeId, portName: outputPortName },
+              portType: type
             });
           }
         }
@@ -397,7 +398,8 @@ const Port = ({
             nodesDispatch?.({
               type: NodesActionType.ADD_CONNECTION,
               output: { nodeId, portName: name },
-              input: { nodeId: inputNodeId, portName: inputPortName }
+              input: { nodeId: inputNodeId, portName: inputPortName },
+              portType: type
             });
             triggerRecalculation();
           }

--- a/src/nodesReducer.ts
+++ b/src/nodesReducer.ts
@@ -22,7 +22,7 @@ import {
 import FlumeCache from "./Cache";
 import { ToastAction, ToastActionTypes } from "./toastsReducer";
 
-const addConnection = (nodes: NodeMap, input, output, portTypes) => {
+const addConnection = (nodes: NodeMap, input, output, portType: string) => {
   const newNodes = {
     ...nodes,
     [input.nodeId]: {
@@ -35,7 +35,8 @@ const addConnection = (nodes: NodeMap, input, output, portTypes) => {
             ...(nodes[input.nodeId].connections.inputs[input.portName] || []),
             {
               nodeId: output.nodeId,
-              portName: output.portName
+              portName: output.portName,
+              portType
             }
           ]
         }
@@ -52,7 +53,8 @@ const addConnection = (nodes: NodeMap, input, output, portTypes) => {
               []),
             {
               nodeId: input.nodeId,
-              portName: input.portName
+              portName: input.portName,
+              portType
             }
           ]
         }
@@ -285,10 +287,16 @@ type ProposedConnection = { nodeId: string; portName: string };
 
 export type NodesAction =
   | {
-      type: NodesActionType.ADD_CONNECTION | NodesActionType.REMOVE_CONNECTION;
+      type: NodesActionType.ADD_CONNECTION;
       input: ProposedConnection;
       output: ProposedConnection;
+      portType: string;
     }
+  | {
+      type: NodesActionType.REMOVE_CONNECTION;
+      input: ProposedConnection;
+      output: ProposedConnection;
+    } 
   | {
       type: NodesActionType.DESTROY_TRANSPUT;
       transput: ProposedConnection;
@@ -340,14 +348,14 @@ const nodesReducer = (
 ) => {
   switch (action.type) {
     case NodesActionType.ADD_CONNECTION: {
-      const { input, output } = action;
+      const { input, output, portType } = action;
       const inputIsNotConnected = !nodes[input.nodeId].connections.inputs[
         input.portName
       ];
       if (inputIsNotConnected) {
         const allowCircular =
           circularBehavior === "warn" || circularBehavior === "allow";
-        const newNodes = addConnection(nodes, input, output, portTypes);
+        const newNodes = addConnection(nodes, input, output, portType);
         const isCircular = checkForCircularNodes(newNodes, output.nodeId);
         if (isCircular && !allowCircular) {
           dispatchToasts?.({

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,6 +273,7 @@ export interface NodeTypeConfig
 export type Connection = {
   nodeId: string;
   portName: string;
+  portType: string;
 };
 
 export type ConnectionMap = { [portName: string]: Connection[] };


### PR DESCRIPTION
I wrote my own NodeRunner to handle the execution flow of the nodes.  
And tried to use [ajv](https://ajv.js.org/) to validate all nodes' inputs and output.  
![Screenshot 2023-10-17 at 11 28 33](https://github.com/chrisjpatty/flume/assets/8834928/fa92ce30-c1e6-4bdf-b9ae-c3214b7627c6)

But it seems that the portType is not written to connection. So I made this PR.  
Please check!
