### PR TITLE
Remove debug console.log statements from production code

### DIFF
--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -15,7 +15,6 @@ export default ({ x, y, onColorPicked, onRequestClose }: ColorPickerProps) => {
 
   const testClickOutside = React.useCallback(
     (e: MouseEvent) => {
-      console.log("testClickOutside", e.type);
       if (wrapper.current && !wrapper.current.contains(e.target as Node)) {
         onRequestClose();
         document.removeEventListener("click", testClickOutside);

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -105,7 +105,6 @@ export default ({
       case "color":
         setColorPickerCoordinates(menuCoordinates);
         setIsPickingColor(true);
-        console.log(menuCoordinates);
         break;
       case "delete":
         dispatch({


### PR DESCRIPTION
## Summary
- Remove console.log statement from ColorPicker testClickOutside function
- Remove console.log statement from Comment handleMenuOption function  
- Preserve debug prop console.logs in NodeEditor for developer debugging

## Test plan
- [ ] Verify ColorPicker still functions correctly when clicking outside to close
- [ ] Verify Comment context menu color picker still works without logging coordinates
- [ ] Confirm debug prop console.logs are still available in NodeEditor when debug=true

🤖 Generated with [Claude Code](https://claude.ai/code)